### PR TITLE
chore: update MohoProgram trait with Spec type and improved API

### DIFF
--- a/crates/runtime-impl/src/runtime.rs
+++ b/crates/runtime-impl/src/runtime.rs
@@ -16,7 +16,7 @@ use crate::RuntimeInput;
 /// # Panics
 ///
 /// If it's incorrect.
-pub fn verify_input<P: MohoProgram>(input: RuntimeInput) -> MohoAttestation {
+pub fn verify_input<P: MohoProgram>(input: RuntimeInput, spec: &P::Spec) -> MohoAttestation {
     let inner_pre_state = deserialize_borsh::<P::State>(input.inner_pre_state())
         .expect("runtime: deserialize pre state");
     let inner_input = deserialize_borsh::<P::StepInput>(input.input_payload())
@@ -34,6 +34,7 @@ pub fn verify_input<P: MohoProgram>(input: RuntimeInput) -> MohoAttestation {
         input.into_pre_state(),
         &inner_pre_state,
         &inner_input,
+        spec,
     );
 
     // Check the attestation matches the reference in the input.
@@ -63,6 +64,7 @@ fn compute_transition_attestation<P: MohoProgram>(
     pre_moho_state: MohoState,
     pre_inner_state: &P::State,
     input: &P::StepInput,
+    spec: &P::Spec,
 ) -> StateRefAttestation {
     // Check the input's parent extends it properly.
     let input_ref = P::compute_input_reference(input);
@@ -73,7 +75,8 @@ fn compute_transition_attestation<P: MohoProgram>(
     );
 
     // Compute the transition.
-    let post_state = compute_transition::<P>(pre_state_ref, pre_moho_state, pre_inner_state, input);
+    let post_state =
+        compute_transition::<P>(pre_state_ref, pre_moho_state, pre_inner_state, input, spec);
 
     // Construct the attestation.
     let post_state_commitment = compute_moho_state_commitment(&post_state);
@@ -87,6 +90,7 @@ pub fn compute_transition<P: MohoProgram>(
     pre_moho_state: MohoState,
     pre_inner_state: &P::State,
     input: &P::StepInput,
+    spec: &P::Spec,
 ) -> MohoState {
     // Check the pre-state matches that in the moho pre-state.
     let computed_inner_state_root = P::compute_state_commitment(pre_inner_state);
@@ -105,7 +109,7 @@ pub fn compute_transition<P: MohoProgram>(
     );
 
     // Compute the new state and wrap it.
-    let output = P::process_transition(pre_inner_state, input);
+    let output = P::process_transition(pre_inner_state, spec, input);
     compute_wrapping_moho_state::<P>(pre_moho_state, &output)
 }
 
@@ -130,7 +134,8 @@ fn compute_wrapping_moho_state<P: MohoProgram>(
         None => moho_state.next_predicate().clone(),
     };
 
-    let new_export_state = P::compute_export_state(moho_state.into_export_state(), step_output);
+    let new_export_state =
+        P::compute_next_export_state(moho_state.into_export_state(), step_output);
 
     MohoState::new(post_inner_root, next_predicate, new_export_state)
 }

--- a/crates/runtime-interface/src/traits.rs
+++ b/crates/runtime-interface/src/traits.rs
@@ -14,6 +14,9 @@ pub trait MohoProgram {
     /// Private input to process the next state.
     type StepInput: BorshDeserialize + BorshSerialize;
 
+    /// The specification type that defines program behavior and configuration.
+    type Spec;
+
     /// Output after processing the step input
     type StepOutput;
 
@@ -28,22 +31,26 @@ pub trait MohoProgram {
 
     /// Computes the state transition from the input.
     ///
-    /// If this returns error, proving fails.
-    // TODO make result type
-    fn process_transition(pre_state: &Self::State, inp: &Self::StepInput) -> Self::StepOutput;
+    /// # Panics
+    ///
+    /// Panics if the provided `pre_state`, `spec`, and `inp` violate the program invariant.
+    fn process_transition(
+        pre_state: &Self::State,
+        spec: &Self::Spec,
+        inp: &Self::StepInput,
+    ) -> Self::StepOutput;
 
-    /// Extracts the next predicate key from a step’s output.
+    /// Extracts the next inner predicate key from a step’s output.
     ///
     /// # Returns
     ///
     /// - `Some(PredicateKey)` if the inner predicate key has been updated.
     /// - `None` if there is no update to the inner predicate key.
-    // REVIEW:PG use PredicateKeyBuf instead?
     fn extract_next_predicate(output: &Self::StepOutput) -> Option<PredicateKey>;
 
     /// Extracts the inner state after a transition from the step’s output.
     fn extract_post_state(output: &Self::StepOutput) -> &Self::State;
 
-    /// Computes the updated exported state from the output.
-    fn compute_export_state(export_state: ExportState, output: &Self::StepOutput) -> ExportState;
+    /// Computes the new exported state from the previous one and the step output.
+    fn compute_next_export_state(prev: ExportState, output: &Self::StepOutput) -> ExportState;
 }


### PR DESCRIPTION
## Description

<!--
Provide a brief summary of the changes and the motivation behind them.
-->
- Add `Spec` associated type to `MohoProgram` and thread it through `process_transition` and the runtime call chain
- Rename `compute_export_state` to `compute_next_export_state` for clarity
- Fix stale doc comments (VerifyingKey → PredicateKey, add panic docs)

These changes port the trait updates from the duplicated definition in [alpen](https://github.com/alpenlabs/alpen/blob/main/crates/asm/moho-program/src/traits.rs) back to this upstream crate, so the duplication can be removed.


### Type of Change

<!--
Select the type of change your PR introduces (put an `x` in all that apply):
-->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature/Enhancement (non-breaking change which adds functionality or enhances an existing one)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactor
- [ ] New or updated tests
- [ ] Dependency update
- [ ] Security fix

## Notes to Reviewers

<!--
Anything in particular you want to note that will help reviewers fulfill their role
in reviewing this PR?
-->

## Checklist

<!--
Ensure all the following are checked:
-->

- [ ] I have performed a self-review of my code.
- [ ] I have commented my code where necessary.
- [ ] I have updated the documentation if needed.
- [ ] My changes do not introduce new warnings.
- [ ] I have added tests that prove my changes are effective or that my feature works.
- [ ] New and existing tests pass with my changes.

## Related Issues

<!--
Link any related issues (e.g., `closes #123`, `fixes #456`).
-->
