### PR TITLE
chore(deps): bump strata-common to rc18

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1059,7 +1059,7 @@ dependencies = [
 [[package]]
 name = "strata-codec"
 version = "0.1.0"
-source = "git+https://github.com/alpenlabs/strata-common?tag=v0.1.0-alpha-rc16#a0c346696ffbf2bc95b7fa37174e09d41462efa3"
+source = "git+https://github.com/alpenlabs/strata-common?tag=v0.1.0-alpha-rc18#ac205d292869e15c7a3ae63b94876c75bc89fa78"
 dependencies = [
  "thiserror 2.0.18",
 ]
@@ -1067,7 +1067,7 @@ dependencies = [
 [[package]]
 name = "strata-merkle"
 version = "0.2.0"
-source = "git+https://github.com/alpenlabs/strata-common?tag=v0.1.0-alpha-rc16#a0c346696ffbf2bc95b7fa37174e09d41462efa3"
+source = "git+https://github.com/alpenlabs/strata-common?tag=v0.1.0-alpha-rc18#ac205d292869e15c7a3ae63b94876c75bc89fa78"
 dependencies = [
  "borsh",
  "digest",
@@ -1087,7 +1087,7 @@ dependencies = [
 [[package]]
 name = "strata-predicate"
 version = "0.1.0"
-source = "git+https://github.com/alpenlabs/strata-common?tag=v0.1.0-alpha-rc16#a0c346696ffbf2bc95b7fa37174e09d41462efa3"
+source = "git+https://github.com/alpenlabs/strata-common?tag=v0.1.0-alpha-rc18#ac205d292869e15c7a3ae63b94876c75bc89fa78"
 dependencies = [
  "borsh",
  "hex",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,10 +15,10 @@ moho-types = { path = "crates/types" }
 
 strata-merkle = { git = "https://github.com/alpenlabs/strata-common", features = [
   "ssz",
-], tag = "v0.1.0-alpha-rc16" }
+], tag = "v0.1.0-alpha-rc18" }
 strata-predicate = { git = "https://github.com/alpenlabs/strata-common", features = [
   "schnorr",
-], tag = "v0.1.0-alpha-rc16" }
+], tag = "v0.1.0-alpha-rc18" }
 
 hex = { version = "0.4" }
 sha2 = { version = "0.10.9" }


### PR DESCRIPTION
## Summary

- Bumps `strata-merkle` and `strata-predicate` from `v0.1.0-alpha-rc16` to `v0.1.0-alpha-rc18`.
- First link in a three-repo bump chain (moho → asm → alpen). Without this, asm and alpen cannot adopt rc18 because the moho-trait boundary leaks rc16 `PredicateKey` / `MerkleProofB32` into asm consumers, causing duplicate-version type collisions.
- No source changes needed. `cargo check --workspace --all-targets` and `cargo test --workspace` both pass.

## Out of scope

- Tagging `v0.1-alpha.2`. Will be done after merge so asm can pin to a tag.