### PR TITLE
chore: use tag= for strata-predicate to match downstream specs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1141,7 +1141,7 @@ dependencies = [
 [[package]]
 name = "strata-predicate"
 version = "0.1.0"
-source = "git+https://github.com/alpenlabs/strata-common?rev=v0.1.0-alpha-rc20#75763ada955765fb7cb32dba045c7484f591aa25"
+source = "git+https://github.com/alpenlabs/strata-common?tag=v0.1.0-alpha-rc20#75763ada955765fb7cb32dba045c7484f591aa25"
 dependencies = [
  "borsh",
  "hex",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ strata-merkle = { git = "https://github.com/alpenlabs/strata-common", features =
 ], tag = "v0.1.0-alpha-rc20" }
 strata-predicate = { git = "https://github.com/alpenlabs/strata-common", features = [
   "schnorr",
-], rev = "v0.1.0-alpha-rc20" }
+], tag = "v0.1.0-alpha-rc20" }
 
 bincode = { version = "1.3" }
 const-hex = { version = "1", default-features = false, features = ["alloc"] }


### PR DESCRIPTION
## Description

<!--
Provide a brief summary of the changes and the motivation behind them.
-->
Both forms resolve to the same commit, but Cargo keys lockfile entries by the source URL string, so `?tag=` and `?rev=` are treated as distinct sources. Downstream consumers that declare strata-predicate via `tag=` end up with two compiled copies of the crate in their dep graph. Align on `tag=` to match the convention used elsewhere in the strata workspace.


### Type of Change

<!--
Select the type of change your PR introduces (put an `x` in all that apply):
-->

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature/Enhancement (non-breaking change which adds functionality or enhances an existing one)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactor
- [ ] New or updated tests
- [ ] Dependency update
- [ ] Security fix

## Notes to Reviewers

<!--
Anything in particular you want to note that will help reviewers fulfill their role
in reviewing this PR?
-->

## Checklist

<!--
Ensure all the following are checked:
-->

- [X] I have performed a self-review of my code.
- [X] I have commented my code where necessary.
- [X] I have updated the documentation if needed.
- [X] My changes do not introduce new warnings.
- [X] I have added tests that prove my changes are effective or that my feature works.
- [X] New and existing tests pass with my changes.

## Related Issues

<!--
Link any related issues (e.g., `closes #123`, `fixes #456`).
-->
