### PR TITLE
chore(deps): bump zkaleido to v0.1-beta.5

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -616,7 +616,7 @@ dependencies = [
  "strata-predicate",
  "thiserror",
  "tree_hash",
- "zkaleido 0.1.0 (git+https://github.com/alpenlabs/zkaleido?tag=v0.1-beta.5)",
+ "zkaleido",
  "zkaleido-native-adapter",
 ]
 
@@ -661,7 +661,7 @@ dependencies = [
  "thiserror",
  "tree_hash",
  "tree_hash_derive",
- "zkaleido 0.1.0 (git+https://github.com/alpenlabs/zkaleido?tag=v0.1-beta.5)",
+ "zkaleido",
 ]
 
 [[package]]
@@ -1119,7 +1119,7 @@ dependencies = [
 [[package]]
 name = "strata-codec"
 version = "0.1.0"
-source = "git+https://github.com/alpenlabs/strata-common?tag=v0.1.0-alpha-rc25#064ebd8a932936bb3255a7a80db235c2f50bf04a"
+source = "git+https://github.com/alpenlabs/strata-common?tag=v0.1.0-alpha-rc26#f2c6703b2a641838e0058730bb076fdf9a9dbdff"
 dependencies = [
  "thiserror",
 ]
@@ -1127,7 +1127,7 @@ dependencies = [
 [[package]]
 name = "strata-merkle"
 version = "0.2.0"
-source = "git+https://github.com/alpenlabs/strata-common?tag=v0.1.0-alpha-rc25#064ebd8a932936bb3255a7a80db235c2f50bf04a"
+source = "git+https://github.com/alpenlabs/strata-common?tag=v0.1.0-alpha-rc26#f2c6703b2a641838e0058730bb076fdf9a9dbdff"
 dependencies = [
  "borsh",
  "digest 0.10.7",
@@ -1147,7 +1147,7 @@ dependencies = [
 [[package]]
 name = "strata-predicate"
 version = "0.1.0"
-source = "git+https://github.com/alpenlabs/strata-common?tag=v0.1.0-alpha-rc25#064ebd8a932936bb3255a7a80db235c2f50bf04a"
+source = "git+https://github.com/alpenlabs/strata-common?tag=v0.1.0-alpha-rc26#f2c6703b2a641838e0058730bb076fdf9a9dbdff"
 dependencies = [
  "hex",
  "k256",
@@ -1557,17 +1557,6 @@ checksum = "b97154e67e32c85465826e8bcc1c59429aaaf107c1e4a9e53c8d8ccd5eff88d0"
 [[package]]
 name = "zkaleido"
 version = "0.1.0"
-source = "git+https://github.com/alpenlabs/zkaleido?tag=v0.1-beta.4#5ea37d52d253ff890efbfbd1422aad4c3def58f7"
-dependencies = [
- "bincode",
- "borsh",
- "serde",
- "thiserror",
-]
-
-[[package]]
-name = "zkaleido"
-version = "0.1.0"
 source = "git+https://github.com/alpenlabs/zkaleido?tag=v0.1-beta.5#0ee0c39cd1a05a79db91266126550f9aa61b4524"
 dependencies = [
  "bincode",
@@ -1586,13 +1575,13 @@ dependencies = [
  "k256",
  "rand_core 0.6.4",
  "serde",
- "zkaleido 0.1.0 (git+https://github.com/alpenlabs/zkaleido?tag=v0.1-beta.5)",
+ "zkaleido",
 ]
 
 [[package]]
 name = "zkaleido-sp1-groth16-verifier"
 version = "0.1.0"
-source = "git+https://github.com/alpenlabs/zkaleido?tag=v0.1-beta.4#5ea37d52d253ff890efbfbd1422aad4c3def58f7"
+source = "git+https://github.com/alpenlabs/zkaleido?tag=v0.1-beta.5#0ee0c39cd1a05a79db91266126550f9aa61b4524"
 dependencies = [
  "blake3",
  "borsh",
@@ -1601,7 +1590,7 @@ dependencies = [
  "sha2 0.10.9",
  "substrate-bn",
  "thiserror",
- "zkaleido 0.1.0 (git+https://github.com/alpenlabs/zkaleido?tag=v0.1-beta.4)",
+ "zkaleido",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -616,7 +616,7 @@ dependencies = [
  "strata-predicate",
  "thiserror",
  "tree_hash",
- "zkaleido",
+ "zkaleido 0.1.0 (git+https://github.com/alpenlabs/zkaleido?tag=v0.1-beta.5)",
  "zkaleido-native-adapter",
 ]
 
@@ -661,7 +661,7 @@ dependencies = [
  "thiserror",
  "tree_hash",
  "tree_hash_derive",
- "zkaleido",
+ "zkaleido 0.1.0 (git+https://github.com/alpenlabs/zkaleido?tag=v0.1-beta.5)",
 ]
 
 [[package]]
@@ -1562,6 +1562,17 @@ dependencies = [
  "bincode",
  "borsh",
  "serde",
+ "thiserror",
+]
+
+[[package]]
+name = "zkaleido"
+version = "0.1.0"
+source = "git+https://github.com/alpenlabs/zkaleido?tag=v0.1-beta.5#0ee0c39cd1a05a79db91266126550f9aa61b4524"
+dependencies = [
+ "bincode",
+ "borsh",
+ "serde",
  "ssz",
  "thiserror",
 ]
@@ -1569,13 +1580,13 @@ dependencies = [
 [[package]]
 name = "zkaleido-native-adapter"
 version = "0.1.0"
-source = "git+https://github.com/alpenlabs/zkaleido?tag=v0.1-beta.4#5ea37d52d253ff890efbfbd1422aad4c3def58f7"
+source = "git+https://github.com/alpenlabs/zkaleido?tag=v0.1-beta.5#0ee0c39cd1a05a79db91266126550f9aa61b4524"
 dependencies = [
  "bincode",
  "k256",
  "rand_core 0.6.4",
  "serde",
- "zkaleido",
+ "zkaleido 0.1.0 (git+https://github.com/alpenlabs/zkaleido?tag=v0.1-beta.5)",
 ]
 
 [[package]]
@@ -1590,7 +1601,7 @@ dependencies = [
  "sha2 0.10.9",
  "substrate-bn",
  "thiserror",
- "zkaleido",
+ "zkaleido 0.1.0 (git+https://github.com/alpenlabs/zkaleido?tag=v0.1-beta.4)",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,8 +31,8 @@ serde = { version = "1.0", default-features = false, features = [
 serde_json = { version = "1" }
 sha2 = { version = "0.11.0" }
 thiserror = { version = "2" }
-zkaleido = { git = "https://github.com/alpenlabs/zkaleido", tag = "v0.1-beta.4" }
-zkaleido-native-adapter = { git = "https://github.com/alpenlabs/zkaleido", tag = "v0.1-beta.4" }
+zkaleido = { git = "https://github.com/alpenlabs/zkaleido", tag = "v0.1-beta.5" }
+zkaleido-native-adapter = { git = "https://github.com/alpenlabs/zkaleido", tag = "v0.1-beta.5" }
 
 ssz = { git = "https://github.com/alpenlabs/ssz-gen", tag = "v0.16.0" }
 ssz_codegen = { git = "https://github.com/alpenlabs/ssz-gen", tag = "v0.16.0" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,10 +16,10 @@ moho-types = { path = "crates/types" }
 # strata-common
 strata-merkle = { git = "https://github.com/alpenlabs/strata-common", features = [
   "ssz",
-], tag = "v0.1.0-alpha-rc25" }
+], tag = "v0.1.0-alpha-rc26" }
 strata-predicate = { git = "https://github.com/alpenlabs/strata-common", features = [
   "schnorr",
-], tag = "v0.1.0-alpha-rc25" }
+], tag = "v0.1.0-alpha-rc26" }
 
 bincode = { version = "1.3" }
 const-hex = { version = "1", default-features = false, features = ["alloc"] }


### PR DESCRIPTION
## Description

Bumps the `zkaleido` and `zkaleido-native-adapter` git dependencies from tag `v0.1-beta.4` to `v0.1-beta.5`, and bumps `strata-common` (`strata-merkle`, `strata-predicate`) from `v0.1.0-alpha-rc25` to `v0.1.0-alpha-rc26`.

The strata-common bump is required to fully drop `v0.1-beta.4`: `strata-predicate` pulls in `zkaleido-sp1-groth16-verifier`, which was still pinned to `v0.1-beta.4` (and transitively to `zkaleido v0.1-beta.4`). rc26 repins that verifier to `v0.1-beta.5`, so the lockfile no longer references beta.4 at all.

### Type of Change

- [x] Dependency update

## Notes to Reviewers

`cargo check --workspace` passes.

## Checklist

- [x] I have performed a self-review of my code.
- [x] My changes do not introduce new warnings.

## Related Issues
