### PR TITLE
chore: upgrade dependencies

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -810,9 +810,9 @@ dependencies = [
 
 [[package]]
 name = "ruint"
-version = "1.19.0"
+version = "1.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "45caf26f647c19115bf9c453c70ffe4a4a3a6390dceebd942610584f99b8ddce"
+checksum = "f5e99bff0393163bb25029a6af25d3d8d202ba5b5438a74d1bd8789f5c822970"
 dependencies = [
  "proptest",
  "rand 0.8.7",
@@ -1064,7 +1064,7 @@ dependencies = [
 [[package]]
 name = "strata-codec"
 version = "0.1.0"
-source = "git+https://github.com/alpenlabs/strata-common?tag=v0.3.0#60ae4f3b95d2f034b9ee0bfea698d8f5ca05234b"
+source = "git+https://github.com/alpenlabs/strata-common?tag=v0.4.0-rc.2#4e9dedf044e84e78cb3d2c9fbce262777735de09"
 dependencies = [
  "thiserror",
 ]
@@ -1072,7 +1072,7 @@ dependencies = [
 [[package]]
 name = "strata-merkle"
 version = "0.2.0"
-source = "git+https://github.com/alpenlabs/strata-common?tag=v0.3.0#60ae4f3b95d2f034b9ee0bfea698d8f5ca05234b"
+source = "git+https://github.com/alpenlabs/strata-common?tag=v0.4.0-rc.2#4e9dedf044e84e78cb3d2c9fbce262777735de09"
 dependencies = [
  "borsh",
  "digest 0.10.7",
@@ -1092,7 +1092,7 @@ dependencies = [
 [[package]]
 name = "strata-predicate"
 version = "0.1.0"
-source = "git+https://github.com/alpenlabs/strata-common?tag=v0.3.0#60ae4f3b95d2f034b9ee0bfea698d8f5ca05234b"
+source = "git+https://github.com/alpenlabs/strata-common?tag=v0.4.0-rc.2#4e9dedf044e84e78cb3d2c9fbce262777735de09"
 dependencies = [
  "hex",
  "k256",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,10 +16,10 @@ moho-types = { path = "crates/types" }
 # strata-common
 strata-merkle = { git = "https://github.com/alpenlabs/strata-common", features = [
   "ssz",
-], tag = "v0.3.0" }
+], tag = "v0.4.0-rc.2" }
 strata-predicate = { git = "https://github.com/alpenlabs/strata-common", features = [
   "schnorr",
-], tag = "v0.3.0" }
+], tag = "v0.4.0-rc.2" }
 
 bincode = { version = "1.3" }
 const-hex = { version = "1", default-features = false, features = ["alloc"] }

--- a/crates/recursive-proof/src/test_utils.rs
+++ b/crates/recursive-proof/src/test_utils.rs
@@ -25,10 +25,11 @@ impl SchnorrPredicate {
     /// Creates a new random Schnorr predicate.
     pub fn new_random() -> Self {
         let signing_key = SigningKey::random(&mut rand_core::OsRng);
-        let predicate = PredicateKey::new(
+        let predicate = PredicateKey::try_new(
             PredicateTypeId::Bip340Schnorr,
             signing_key.verifying_key().to_bytes().to_vec(),
-        );
+        )
+        .expect("valid predicate key");
         Self {
             signing_key,
             predicate,


### PR DESCRIPTION
## Description

Upgrade ruint from 1.19.0 to 1.20.0 and update
strata-common dependencies from v0.3.0 to v0.4.0-rc.2.

This includes strata-codec, strata-merkle, and
strata-predicate packages to align with the latest
release candidate of strata-common.

### Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature/Enhancement (non-breaking change which adds functionality or enhances an existing one)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactor
- [ ] New or updated tests
- [x] Dependency update
- [x] Security fix

## Notes to Reviewers

## Checklist

- [x] I have performed a self-review of my code.
- [x] I have commented my code where necessary.
- [x] I have updated the documentation if needed.
- [x] My changes do not introduce new warnings.
- [x] I have added tests that prove my changes are effective or that my feature works.
- [x] New and existing tests pass with my changes.

## Related Issues

STR-4232